### PR TITLE
Fix "404 file not found” error

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -12,7 +12,7 @@ content:
   sources:
 #    - url: .
     - url: https://github.com/SEMICeu/core-vocs-handbook
-      branches: [ feature/bootstrap-repo ]
+      branches: [ feature/SM16-32 ]
       start_path: docs
 ui:
   bundle:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -12,7 +12,7 @@ content:
   sources:
 #    - url: .
     - url: https://github.com/SEMICeu/core-vocs-handbook
-      branches: [ feature/SM16-32 ]
+      branches: [ develop ]
       start_path: docs
 ui:
   bundle:


### PR DESCRIPTION
GH workflow has set a non-existent branch as a source. That was causing an empty build which in turn resulted in 404 error.
This change sets `develop` branch as the source for build and published pages.