### PR TITLE
Enable generation of documentation for any branch in handbook repository

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -10,9 +10,7 @@ site:
 
 content:
   sources:
-#    - url: .
-    - url: https://github.com/SEMICeu/core-vocs-handbook
-      branches: [ develop ]
+    - url: .
       start_path: docs
 ui:
   bundle:


### PR DESCRIPTION
The change lets contributors to build and publish documentation from any branch they are working on (through the GitHub action).

_Note that `main.yml` file (CI) is already enabled for any standard branch._