### PR TITLE
Set 2.0.0 as the default version

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: SEMIC
-  start_page: ROOT::index.adoc
+  start_page: 2.0.0@ROOT::index.adoc
 
 antora:
   extensions:


### PR DESCRIPTION
If not specified explicitly, Anotra determines the latest component version based on its [ordering rules](https://docs.antora.org/antora/latest/how-component-versions-are-sorted/). In this scenario, develop is selected as the default version. This change sets 2.0.0 as the explicit default version.